### PR TITLE
修复了在Windows 10 Mobile设备上无法启动的问题

### DIFF
--- a/src/WebPViewerMobile/Package.appxmanifest
+++ b/src/WebPViewerMobile/Package.appxmanifest
@@ -9,7 +9,7 @@
   <Identity
     Name="fa53daad-bb02-465d-97ab-5a28c439e5be"
     Publisher="CN=Baka632"
-    Version="1.0.3.0" />
+    Version="1.0.4.0" />
 
   <mp:PhoneIdentity PhoneProductId="fa53daad-bb02-465d-97ab-5a28c439e5be" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 

--- a/src/WebPViewerMobile/Views/MainPage.xaml.cs
+++ b/src/WebPViewerMobile/Views/MainPage.xaml.cs
@@ -16,9 +16,7 @@ namespace WebPViewerMobile.Views
     public sealed partial class MainPage : Page
     {
         public MainPageViewModel ViewModel { get; }
-        public static CoreDispatcher CoreDispatcher { get; private set; }
 
-        internal static readonly DispatcherQueue DispatcherQueue = DispatcherQueue.GetForCurrentThread();
         private bool IsTitleBarTextBlockForwardBegun = false;
         private bool IsFirstRun = true;
 
@@ -27,7 +25,6 @@ namespace WebPViewerMobile.Views
             this.InitializeComponent();
 
             AcrylicHelper.TrySetAcrylicBrush(this);
-            CoreDispatcher = Dispatcher;
             ViewModel = new MainPageViewModel(ContentFrame);
             TitleBarHelper.BackButtonVisibilityChangedEvent += OnBackButtonVisibilityChanged;
             TitleBarHelper.TitleBarVisibilityChangedEvent += OnTitleBarVisibilityChanged;


### PR DESCRIPTION
原因是在 ```MainPage.xaml.cs``` 中，我们声明了一个类型为 ```DispatcherQueue``` 的静态字段，而 ```DispatcherQueue``` 类型在 Windows 10 Mobile中不受支持。

由于我们不使用此字段，因此我们直接移除了它。